### PR TITLE
fix: Missing `open` in ack count.

### DIFF
--- a/bolts/02-wire-protocol.md
+++ b/bolts/02-wire-protocol.md
@@ -80,7 +80,7 @@ explicitly separated from the protocol.
 A node MUST send an `init` message immediately immediately after it
 has validated the `authenticate` message.  A node MUST set the `ack`
 field in the `init` message to the the sum of previously-processed
-messages of types `open_commit_sig`, `update_commit`,
+messages of types `open`, `open_commit_sig`, `update_commit`,
 `update_revocation`, `close_shutdown` and `close_signature`.
 
 A node SHOULD set the `features` field of the `init` message to a


### PR DESCRIPTION
This change was introduced in ElementsProject/lightning@56b0f03c5a77d058155584978535e97721ba524a, this is just synching back to the spec.