### PR TITLE
Make blinded paths mandatory to pay offers

### DIFF
--- a/12-offer-encoding.md
+++ b/12-offer-encoding.md
@@ -5,10 +5,10 @@
   * [Limitations of BOLT 11](#limitations-of-bolt-11)
   * [Payment Flow Scenarios](#payment-flow-scenarios)
   * [Encoding](#encoding)
-  * [TLV Fields](#tlv-fields)
-  * [Invoices](#invoices)
+  * [Signature calculation](#signature-calculation)
   * [Offers](#offers)
   * [Invoice Requests](#invoice-requests)
+  * [Invoices](#invoices)
   * [Invoice Errors](#invoice-errors)
 
 # Limitations of BOLT 11
@@ -108,7 +108,7 @@ zzzzz
 
 See [format-string-test.json](bolt12/format-string-test.json).
 
-## Signature Calculation
+# Signature Calculation
 
 All signatures are created as per
 [BIP-340](https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki),

--- a/12-offer-encoding.md
+++ b/12-offer-encoding.md
@@ -555,6 +555,8 @@ using `onion_message` `invoice` field.
    * [`u32`:`fee_base_msat`]
    * [`u32`:`fee_proportional_millionths`]
    * [`u16`:`cltv_expiry_delta`]
+   * [`u64`:`htlc_minimum_msat`]
+   * [`u64`:`htlc_maximum_msat`]
    * [`u16`:`flen`]
    * [`flen*byte`:`features`]
 


### PR DESCRIPTION
Forcing blinded paths in invoices costs us nothing and without it we lose the features from `payment_secret` and `payment_metadata`.