### PR TITLE
Use full public keys

### DIFF
--- a/01-messaging.md
+++ b/01-messaging.md
@@ -239,7 +239,6 @@ The following convenience types are also defined:
 * `signature`: a 64-byte bitcoin Elliptic Curve signature
 * `bip340sig`: a 64-byte bitcoin Elliptic Curve Schnorr signature as per [BIP-340](https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki)
 * `point`: a 33-byte Elliptic Curve point (compressed encoding as per [SEC 1 standard](http://www.secg.org/sec1-v2.pdf#subsubsection.2.3.3))
-* `point32`: a 32-byte x-only Elliptic Curve point.
 * `short_channel_id`: an 8 byte value identifying a channel (see [BOLT #7](07-routing-gossip.md#definition-of-short-channel-id))
 * `bigsize`: a variable-length, unsigned integer similar to Bitcoin's CompactSize encoding, but big-endian.  Described in [BigSize](#appendix-a-bigsize-test-vectors).
 * `utf8`: a byte as part of a UTF-8 string.  A writer MUST ensure an array of these is a valid UTF-8 string, a reader MAY reject any messages containing an array of these which is not a valid UTF-8 string.

--- a/12-offer-encoding.md
+++ b/12-offer-encoding.md
@@ -220,7 +220,7 @@ The human-readable prefix for offers is `lno`.
         * [`tu64`:`max`]
     1. type: 30 (`node_id`)
     2. data:
-        * [`point32`:`node_id`]
+        * [`point`:`node_id`]
     1. type: 54 (`send_invoice`)
     1. type: 34 (`refund_for`)
     2. data:
@@ -369,7 +369,7 @@ invoices is `lnr`.
         * [`tu64`:`quantity`]
     1. type: 38 (`payer_key`)
     2. data:
-        * [`point32`:`key`]
+        * [`point`:`key`]
     1. type: 39 (`payer_note`)
     2. data:
         * [`...*utf8`:`note`]
@@ -508,7 +508,7 @@ using `onion_message` `invoice` field.
         * [`...*utf8`:`issuer`]
     1. type: 30 (`node_id`)
     2. data:
-        * [`point32`:`node_id`]
+        * [`point`:`node_id`]
     1. type: 32 (`quantity`)
     2. data:
         * [`tu64`:`quantity`]
@@ -517,7 +517,7 @@ using `onion_message` `invoice` field.
         * [`sha256`:`refunded_payment_hash`]
     1. type: 38 (`payer_key`)
     2. data:
-        * [`point32`:`key`]
+        * [`point`:`key`]
     1. type: 39 (`payer_note`)
     2. data:
         * [`...*utf8`:`note`]


### PR DESCRIPTION
It was suggested to use a more compact x-only 32-bytes point for the public keys but this small optimization adds complexity elsewhere, instead we use the standard 33-bytes point that's already used everywhere else.