### PR TITLE
Remove special carve out for splice closes

### DIFF
--- a/.aspell.en.pws
+++ b/.aspell.en.pws
@@ -389,3 +389,4 @@ sats
 quiesce
 quiescing
 SomeThing
+commitsigs

--- a/.aspell.en.pws
+++ b/.aspell.en.pws
@@ -386,3 +386,6 @@ csv
 CHECKSIGVERIFY
 IFDUP
 sats
+quiesce
+quiescing
+SomeThing

--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -506,6 +506,10 @@ a new one.  For simplicity, splicing takes place once a channel is
 Operation returns to normal once negotiation is done (while waiting
 for the splice transaction(s) to confirm).
 
+The splice is finally terminated when both sides send
+`splice_complete` to indicate that one of the splice transactions
+reached acceptable depth.
+
 ### The `splice` Message
 
 1. type: 74 (`splice`)
@@ -596,6 +600,22 @@ them.  If your peer adds a massive amount to the channel, then you
 only have to add more reserve if you want to contribute to the splice
 (and you can use `tx_remove_output` and/or `tx_remove_input` part-way
 through if this happens).
+
+## Splice Completion
+
+Each node:
+- if any splice transaction reaches depth 6:
+  - MUST send `splice_locked`.
+
+Once a node has received and sent `splice_locked`:
+  - MUST consider the successful splice to be the new funding
+    transaction for all future `commitment_signed` and splice operations.
+  - MUST discard the previous funding transaction and other splice operations.
+  - MUST send a new `commitment_signed` (with no `splice_commitsigs`).
+
+On reconnection:
+  - MUST retransmit the last `splice_locked` if the peer did not
+    acknowledge the `commitment_signed`.
 
 ## Channel Close
 

--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -1006,7 +1006,7 @@ A sending node:
     between implementations.
   - if it is _not responsible_ for paying the Bitcoin fee:
     - SHOULD NOT offer `amount_msat` if, once the remote node adds that HTLC to
-    its commitment transaction, it cannot pay the fee for the updated local or
+    any of its commitment transactions, it cannot pay the fee for the updated local or
     remote transaction at the current `feerate_per_kw` while maintaining its
     channel reserve.
   - MUST offer `amount_msat` greater than 0.
@@ -1082,6 +1082,9 @@ reach a state where it is unable to send or receive any non-dust HTLC while
 maintaining its channel reserve (because of the increased weight of the
 commitment transaction), resulting in a degraded channel. See [#728](https://github.com/lightningnetwork/lightning-rfc/issues/728)
 for more details.
+
+If splicing is supported, there can be more than one commitment transaction
+at a time: proposed changes must be valid for all of them.
 
 ### Removing an HTLC: `update_fulfill_htlc`, `update_fail_htlc`, and `update_fail_malformed_htlc`
 
@@ -1315,6 +1318,8 @@ given in [BOLT #3](03-transactions.md#fee-calculation).
 The node _responsible_ for paying the Bitcoin fee:
   - SHOULD send `update_fee` to ensure the current fee rate is sufficient (by a
       significant margin) for timely processing of the commitment transaction.
+  - MUST NOT set `feerate_per_kw` in excess of what it can afford on any of the receiving node's
+    current commitment transactions.
 
 The node _not responsible_ for paying the Bitcoin fee:
   - MUST NOT send `update_fee`.
@@ -1325,7 +1330,7 @@ A receiving node:
   - if the sender is not responsible for paying the Bitcoin fee:
     - MUST fail the channel.
   - if the sender cannot afford the new fee rate on the receiving node's
-  current commitment transaction:
+  current commitment transactions:
     - SHOULD fail the channel,
       - but MAY delay this check until the `update_fee` is committed.
 
@@ -1350,6 +1355,9 @@ channel creation always pays the fees for the commitment transaction),
 it's simplest to only allow it to set fee levels; however, as the same
 fee rate applies to HTLC transactions, the receiving node must also
 care about the reasonableness of the fee.
+
+If splicing is supported, there can be more than one commitment transaction
+at a time: proposed changes must be valid for all of them.
 
 ## Message Retransmission
 

--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -1158,12 +1158,26 @@ sign the resulting transaction (as defined in [BOLT #3](03-transactions.md)), an
    * [`signature`:`signature`]
    * [`u16`:`num_htlcs`]
    * [`num_htlcs*signature`:`htlc_signature`]
+   * [`commitment_signed_tlvs`:`tlvs`]
+
+1. `tlv_stream`: `commitment_signed_tlvs`
+2. types:
+    1. type: 0 (`splice_commitsigs`)
+    2. data:
+        * [`...*commitsigs`:`sigs`]
+
+1. subtype: `commitsigs`
+2. data:
+   * [`signature`:`commit_signature`]
+   * [`u16`:`num_htlcs`]
+   * [`num_htlcs*signature`:`htlc_signature`]
+
 
 #### Requirements
 
 A sending node:
   - MUST NOT send a `commitment_signed` message that does not include any
-updates.
+updates, or add or remove splices.
   - MAY send a `commitment_signed` message that only
 alters the fee.
   - MAY send a `commitment_signed` message that doesn't
@@ -1174,6 +1188,7 @@ fee changes).
     to the ordering of the commitment transaction (see [BOLT #3](03-transactions.md#transaction-input-and-output-ordering)).
   - if it has not recently received a message from the remote node:
       - SHOULD use `ping` and await the reply `pong` before sending `commitment_signed`.
+  - MUST send a `commitsigs` for each splice in progress, in increasing feerate order.
 
 A receiving node:
   - once all pending updates are applied:
@@ -1183,6 +1198,10 @@ A receiving node:
     commitment transaction:
       - MUST fail the channel.
   - if any `htlc_signature` is not valid for the corresponding HTLC transaction OR non-compliant with LOW-S-standard rule <sup>[LOWS](https://github.com/bitcoin/bitcoin/pull/6769)</sup>:
+    - MUST fail the channel.
+  - if there is not exactly one `commitsigs` for each splice in progress:
+    - MUST fail the channel.
+  - if `commit_signature`, `num_htlcs` or `htlc_signature` is not correct as specified above for each splice:
     - MUST fail the channel.
   - MUST respond with a `revoke_and_ack` message.
 
@@ -1202,6 +1221,11 @@ output HTLCs are fully resolved.
 Note that the `htlc_signature` implicitly enforces the time-lock mechanism in the case of offered HTLCs being timed out or received HTLCs being spent. This is done to reduce fees by creating smaller scripts compared to explicitly stating time-locks on HTLC outputs.
 
 The `option_anchor_outputs` allows HTLC transactions to "bring their own fees" by attaching other inputs and outputs, hence the modified signature flags.
+
+Splicing requires us to send and receive redundant signatures, as we
+don't know which (if any) of the splice transactions will end up being
+the new channel.  Increasing feerate order is also the order in which
+splices were negotiated (since each must increase the feerate).
 
 ### Completing the Transition to the Updated State: `revoke_and_ack`
 

--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -458,6 +458,7 @@ channel by indicating that "SomeThing Fundamental is Underway".
 1. type: 2 (`stfu`)
 2. data:
     * [`channel_id`:`channel_id`]
+    * [`u8`:`initiator`]
 
 ### Requirements
 
@@ -465,6 +466,10 @@ The sender of `stfu`:
   - MUST NOT send `stfu` if any of the sender's htlc additions, htlc removals
     or fee updates are pending for either peer.
   - MUST NOT send `stfu` twice.
+  - if it is replying to an `stfu`:
+    - MUST set `initiator` to 0
+  - otherwise:
+    - MUST set `initiator` to 1
   - MUST set `channel_id` to the id of the channel to quiesce.
   - MUST now consider the channel to be quiescing.
   - MUST NOT send an update message after `stfu`.
@@ -483,8 +488,14 @@ Upon disconnection:
 
 The normal use would be to cease sending updates, then wait for all
 the current updates to be acknowledged by both peers, then start
-quiescence.  If both sides send `stfu` simultaneously, the result is
-exactly the same as if one had replied to the other.
+quiescence.  For some protocols, choosing the initiator matters,
+so this flag is sent.
+
+If both sides send `stfu` simultaneously, they will both set
+`initiator` to `1`, in which case the "initiator" is arbitrarily
+considered to be the channel funder (the sender of `open_channel`).
+The quiescence effect is exactly the same as if one had replied to the
+other.
 
 ## Channel Close
 

--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -500,10 +500,11 @@ other.
 ## Splicing
 
 Splicing is the term given for replacing the funding transaction with
-a new one.  For simplicity, no other changes can be made while the new
-transaction is being negotiated, but operation returns to normal once
-negotiation is done (while waiting for the splice transaction(s) to
-confirm).
+a new one.  For simplicity, splicing takes place once a channel is
+[quiescent](#channel-quiescence).
+
+Operation returns to normal once negotiation is done (while waiting
+for the splice transaction(s) to confirm).
 
 ### The `splice` Message
 
@@ -512,43 +513,37 @@ confirm).
    * [`chain_hash`:`chain_hash`]
    * [`channel_id`:`channel_id`]
    * [`u32`:`funding_feerate_perkw`]
-   * [`u64`:`generation`]
-   * [`point`:`payment_basepoint`]
-   * [`point`:`first_per_commitment_point`]
-   * [`point`:`next_per_commitment_point`]
+   * [`point`:`funding_pubkey`]
+
+1. type: 76 (`splice_ack`)
+2. data:
+   * [`chain_hash`:`chain_hash`]
+   * [`channel_id`:`channel_id`]
+   * [`point`:`funding_pubkey`]
 
 #### Requirements
 
-The sender:
+The sender of `splice`:
+- MUST have successfully initiated quiescence.
 - MUST NOT send `splice` before sending and receiving `funding_locked`.
-- MUST NOT send another splice message while a splice is being negotiated.
-- MUST NOT send a splice message after sending uncommitted changes.
-- If a splice is in progress:
+- MUST NOT send `splice` while a splice is being negotiated.
+- If any splice is in progress:
   - MUST NOT send a splice message with `funding_feerate_perkw` which is less than 1.25 the previous `funding_feerate_perkw` (rounded down).
-- MUST NOT send other channel updates until splice negotiation has completed.
 
-The receiver:
-- SHOULD fail the splice if there is an ongoing splice, and the `funding_feerate_perkw` is not at least 1.25 the previous `funding_feerate_perkw` (rounded down).
-- MUST respond with a `splice` message of its own if it has not already.
-- MUST NOT reply with `splice` until all commitment updates are resolved by bother peers.
-- MAY set `funding_feerate_perkw` below the received value.
-- MUST use the higher of the two `funding_feerate_perkw` as the feerate for
-  the splice.
-- MUST NOT send other channel updates until splice negotiation has completed.
+The receiver of `splice`:
+- SHOULD fail the connection if there is an ongoing splice, and the `funding_feerate_perkw` is not at least 1.25 the previous `funding_feerate_perkw` (rounded down).
+- MUST respond with `splice_ack` containing its own `funding_pubkey`.
+- MUST begin splice negotiation.
+
+The receiver of `splice_ack`:
+- MUST begin splice negotiation.
 
 
 #### Rationale
 
-Both sides agree to a splice: there is no harm in agreeing to a splice
-with a high feerate (presumably the recipient will not contribute to
-the splice which they consider to be overpaying).
-
-Any pending updates are flushed before sending, but the reply must
-wait until all changes are resolved..  So in the case where the A
-sends `splice` while B has just added an HTLC, then B will have to
-send `commitment_signed`, then A will have to reply with
-`revoke_and_ack` then `commitment_signed`, the B will have to also
-reply with `revoke_and_ack` before it can finally reply with `splice`.
+There is no harm in agreeing to a splice with a high feerate
+(presumably the recipient will not contribute to the splice which they
+consider to be overpaying).
 
 ## Splice Negotiation
 
@@ -560,10 +555,6 @@ they both send consecutive `tx_complete`.
 
 (Note that many of these messages have their own, additional
 requirements detailed elsewhere).
-
-The initiator is defined as the side which offered the higher
-`funding_feerate_perkw`, or if both sides are equal, the lower
-SEC1-encoded node_id.
 
 The initiator:
 - MUST `tx_add_input` an input which spends the current funding transaction output.
@@ -591,6 +582,7 @@ Upon receipt of consecutive `tx_complete`s, each node:
 
 - Upon receipt of `tx_signatures` for the splice transaction:
   - MUST consider splice negotiation complete.
+  - MUST consider the connection no longer quiescent.
 
 On reconnection:
 - MUST retransmit the last splice `tx_signatures` (if any).

--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -497,6 +497,114 @@ considered to be the channel funder (the sender of `open_channel`).
 The quiescence effect is exactly the same as if one had replied to the
 other.
 
+## Splicing
+
+Splicing is the term given for replacing the funding transaction with
+a new one.  For simplicity, no other changes can be made while the new
+transaction is being negotiated, but operation returns to normal once
+negotiation is done (while waiting for the splice transaction(s) to
+confirm).
+
+### The `splice` Message
+
+1. type: 74 (`splice`)
+2. data:
+   * [`chain_hash`:`chain_hash`]
+   * [`channel_id`:`channel_id`]
+   * [`u32`:`funding_feerate_perkw`]
+   * [`u64`:`generation`]
+   * [`point`:`payment_basepoint`]
+   * [`point`:`first_per_commitment_point`]
+   * [`point`:`next_per_commitment_point`]
+
+#### Requirements
+
+The sender:
+- MUST NOT send `splice` before sending and receiving `funding_locked`.
+- MUST NOT send another splice message while a splice is being negotiated.
+- MUST NOT send a splice message after sending uncommitted changes.
+- If a splice is in progress:
+  - MUST NOT send a splice message with `funding_feerate_perkw` which is less than 1.25 the previous `funding_feerate_perkw` (rounded down).
+- MUST NOT send other channel updates until splice negotiation has completed.
+
+The receiver:
+- SHOULD fail the splice if there is an ongoing splice, and the `funding_feerate_perkw` is not at least 1.25 the previous `funding_feerate_perkw` (rounded down).
+- MUST respond with a `splice` message of its own if it has not already.
+- MUST NOT reply with `splice` until all commitment updates are resolved by bother peers.
+- MAY set `funding_feerate_perkw` below the received value.
+- MUST use the higher of the two `funding_feerate_perkw` as the feerate for
+  the splice.
+- MUST NOT send other channel updates until splice negotiation has completed.
+
+
+#### Rationale
+
+Both sides agree to a splice: there is no harm in agreeing to a splice
+with a high feerate (presumably the recipient will not contribute to
+the splice which they consider to be overpaying).
+
+Any pending updates are flushed before sending, but the reply must
+wait until all changes are resolved..  So in the case where the A
+sends `splice` while B has just added an HTLC, then B will have to
+send `commitment_signed`, then A will have to reply with
+`revoke_and_ack` then `commitment_signed`, the B will have to also
+reply with `revoke_and_ack` before it can finally reply with `splice`.
+
+## Splice Negotiation
+
+The splice negotiation is very similar to the `init_rbf` negotiation:
+both sides alternate sending `tx_add_input` and `tx_add_output` until
+they both send consecutive `tx_complete`.
+
+### Requirements
+
+(Note that many of these messages have their own, additional
+requirements detailed elsewhere).
+
+The initiator is defined as the side which offered the higher
+`funding_feerate_perkw`, or if both sides are equal, the lower
+SEC1-encoded node_id.
+
+The initiator:
+- MUST `tx_add_input` an input which spends the current funding transaction output.
+- MUST `tx_add_output` a zero-value output which pays to the two funding keys using the higher of the two `generation` fields.
+- MUST pay for the common fields.
+
+Upon receipt of consecutive `tx_complete`s, each node:
+- MUST fail negotiation if there is not exactly one input spending the current funding transaction.
+- MUST fail negotiation if there is not exactly one output with zero value paying to the two funding keys (a.k.a. the new channel funding output)
+- MUST calculate the channel capacity for each side:
+  - Start with the previous balance
+  - Add that side's new inputs (excluding the one spending the current funding transaction)
+  - Subtracting each sides new outputs (except the zero-value one paying to the funding keys)
+  - Subtract the total fee that side is paying for the splice transaction.
+- MUST replace the zero-value funding output amount with the total channel capacity.
+- MUST calculate the channel balance for each side:
+  - Subtract any outstanding HTLCs offered by that side.
+- if either side has added an output other than the new channel funding output:
+  - MUST fail the negotiation if the balance for that side is less than 1% of the total channel capacity.
+- SHOULD NOT fail if the splice transaction is nonstandard.
+- MUST increment the commitment number and send `commitment_signed`, including the signatures for the splice transaction.
+
+- Upon receipt of `revoke_and_ack` for the previous commitment:
+  - MUST send `tx_signatures` for the splice transaction.
+
+- Upon receipt of `tx_signatures` for the splice transaction:
+  - MUST consider splice negotiation complete.
+
+On reconnection:
+- MUST retransmit the last splice `tx_signatures` (if any).
+- MUST ignore any redundant `tx_signatures` it receives.
+
+### Rationale
+
+If a side does not meet the reserve requirements, that's OK: but if
+they take funds out of the channel, they must ensure that they do meet
+them.  If your peer adds a massive amount to the channel, then you
+only have to add more reserve if you want to contribute to the splice
+(and you can use `tx_remove_output` and/or `tx_remove_input` part-way
+through if this happens).
+
 ## Channel Close
 
 Nodes can negotiate a mutual close of the connection, which unlike a

--- a/07-routing-gossip.md
+++ b/07-routing-gossip.md
@@ -87,6 +87,8 @@ A node:
     - MUST send the `announcement_signatures` message.
       - MUST NOT send `announcement_signatures` messages until `funding_locked`
       has been sent and received AND the funding transaction has at least six confirmations.
+    - MUST send `announcement_signatures` message after `splice_locked`
+      has been sent and received.
   - otherwise:
     - MUST NOT send the `announcement_signatures` message.
   - upon reconnection (once the above timing requirements have been met):

--- a/07-routing-gossip.md
+++ b/07-routing-gossip.md
@@ -975,9 +975,7 @@ The origin node:
 A node:
   - SHOULD monitor the funding transactions in the blockchain, to identify
   channels that are being closed.
-  - if the funding output of a channel is being spent:
-    - if a `channel_update` had `splicing` in the `channel_flags`:
-      - SHOULD delay 10 blocks considering the output spent.
+  - 12 blocks after the funding output of a channel being spent:
     - SHOULD be removed from the local network view AND be considered closed.
   - if the announced node no longer has any associated open channels:
     - MAY prune nodes added through `node_announcement` messages from their


### PR DESCRIPTION
Solution is now to wait for 12-blocks for all channel closes as per:

https://github.com/lightning/bolts/pull/1004